### PR TITLE
Migrate lisa-loop skill to lisa-wiggum backend

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -66,6 +66,12 @@ If provided, the user lists ordered stages (e.g., "Launch → Monitor → Eval �
 
 These phases also become a `--dim phase <phase1> <phase2> ...` flag on the lisa-wiggum invocation (step 6), so cursor advancement through phases is mechanical. The `## Phases` section in the prompt is for the agent's reference, not for cursor reconstruction.
 
+Then ask:
+
+> How many retries per phase if it fails? (0 = no retries; default 2)
+
+If retries > 0 (e.g., 2): add `--dim retry 0 1 2 --on-exhaust skip` to the Step 6 invocation (values are `0 1 ... N` for N retries). If retries = 0: omit the retry dimension; in this case PHASE FAILED advances the phase (same effect as PHASE COMPLETE).
+
 ### Step 3b — Categories
 
 > Should iterations be classified? Name the categories, or skip.
@@ -112,12 +118,15 @@ Build the prompt using the template below, filling in all placeholders from step
 
 **After the user confirms:**
 
+*Requires the `lisa-wiggum` plugin. If `/lisa-wiggum:lisa-loop` is unavailable, stop and tell the user to install the plugin first.*
+
 1. Write the assembled prompt to `/tmp/lisa-loop-<context-slug>.md` using the Write tool.
 2. Immediately invoke `/lisa-wiggum:lisa-loop` (fully-qualified — do NOT use bare `/lisa-loop`, which would recurse into this skill) with these flags:
    - `--prompt-file /tmp/lisa-loop-<context-slug>.md`
    - `--store <path>` (from step 1)
    - `--context <context-slug>` (from step 4)
    - `--dim phase <phase1> <phase2> ...` (only if phases were configured in step 3a)
+   - `--dim retry 0 1 ... N --on-exhaust skip` (only if retries > 0 from step 3a; values are `0 1 ... N`)
    - `--max-iterations N` (from step 5)
    - `--completion-promise "DONE"`
 
@@ -200,6 +209,9 @@ count 0→30s, 1→30s, 2→60s, 3→60s, 4→120s, 5→240s, 6→480s, 7→960s
      [--<schema-field> value ...] [--extra key=value ...] \
      "concise summary of what happened this iteration"
    ```
+   Note: `--tags` is only valid if the schema includes a `tags` field
+   (check the Step 1 schema probe). The system message emit template
+   already omits `--tags` when no cursor tags are set.
    Use schema-defined fields as top-level flags (e.g., `--status keep
    --change_type progress`). Use `--extra` only for undeclared fields.
    If the logging command fails, note the error and continue —
@@ -217,6 +229,16 @@ count 0→30s, 1→30s, 2→60s, 3→60s, 4→120s, 5→240s, 6→480s, 7→960s
      the retry dimension (or skips on exhaust).
    - If the overall stop condition is met (all work genuinely done):
      output <promise>DONE</promise> to exit the loop entirely.
+   - If none of the above apply (work still in progress):
+     include neither signal — the cursor stays unchanged and the
+     same position runs again next iteration.
+   Signal detection note: these strings are matched as literal text
+   anywhere in the response (case-sensitive, grep -F). Do NOT include
+   "PHASE COMPLETE" or "PHASE FAILED" in code blocks, quoted examples,
+   or prose references — they will trigger the hook regardless.
+   *(if no --dim flags)* Without cursor dimensions, signals are still
+   detected but have no cursor to advance — the loop increments the
+   iteration counter only. Useful for simple monitoring loops.
    *(if pacing)* Compute sleep duration: walk the backoff sequence by
    the consecutive low-activity count from RECALL. If past the end of
    the explicit sequence, double the last value (capped). Execute:

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: lisa-loop
 description: >-
-  Prompt generator for ralph-loop that adds lab-notebook as
+  Prompt generator for lisa-wiggum that adds lab-notebook as
   cross-iteration state. Each iteration can recall prior results,
   do work, and log progress. Use when you need a stateful iterative
   loop with structured memory. Trigger on: stateful loop, lisa-loop,
@@ -12,11 +12,11 @@ argument-hint: --store <path-to-lab-notebook> <task description>
 
 # /lisa-loop — Stateful Loop
 
-Lisa-loop is a prompt generator for ralph-loop. It builds a structured
+Lisa-loop is a prompt generator for lisa-wiggum. It builds a structured
 prompt that gives each iteration access to a `lab-notebook` store —
-adding queryable, persistent state on top of ralph-loop's existing
-file and git-based state. The prompt is static, but the notebook data
-changes each iteration, making the loop behave dynamically.
+adding queryable, persistent state on top of lisa-wiggum's cursor-driven
+loop. The prompt is static, but the notebook data changes each iteration,
+and the cursor advances mechanically based on success/failure signals.
 
 ## Step 1: Parse Arguments
 
@@ -64,6 +64,8 @@ Ask these sub-questions in order. Each is independently skippable. If the user s
 
 If provided, the user lists ordered stages (e.g., "Launch → Monitor → Eval → Summary"). Each phase has implicit entry/exit criteria derived from the task. These go into a `## Phases` section in the generated prompt.
 
+These phases also become a `--dim phase <phase1> <phase2> ...` flag on the lisa-wiggum invocation (step 6), so cursor advancement through phases is mechanical. The `## Phases` section in the prompt is for the agent's reference, not for cursor reconstruction.
+
 ### Step 3b — Categories
 
 > Should iterations be classified? Name the categories, or skip.
@@ -108,7 +110,18 @@ Build the prompt using the template below, filling in all placeholders from step
 >
 > Ready to launch, or adjust?
 
-**After the user confirms, immediately invoke `/ralph-loop:ralph-loop` with the assembled prompt, `--max-iterations N`, and `--completion-promise "DONE"`. No preamble, no summary, no "launching now" text. Just call the Skill tool.**
+**After the user confirms:**
+
+1. Write the assembled prompt to `/tmp/lisa-loop-<context-slug>.md` using the Write tool.
+2. Immediately invoke `/lisa-wiggum:lisa-loop` (fully-qualified — do NOT use bare `/lisa-loop`, which would recurse into this skill) with these flags:
+   - `--prompt-file /tmp/lisa-loop-<context-slug>.md`
+   - `--store <path>` (from step 1)
+   - `--context <context-slug>` (from step 4)
+   - `--dim phase <phase1> <phase2> ...` (only if phases were configured in step 3a)
+   - `--max-iterations N` (from step 5)
+   - `--completion-promise "DONE"`
+
+No preamble, no summary, no "launching now" text. Just write the file, then call the Skill tool.
 
 ---
 
@@ -128,9 +141,9 @@ Available fields: <comma-separated list from lab-notebook schema output, with ty
 
 ## Phases *(if configured)*
 <numbered list of phases from step 3>
-Determine current phase by querying notebook entries. Transition to the next
-phase when its exit criteria are met. The stop condition applies after the
-final phase.
+The cursor advances through phases mechanically (via --dim phase).
+The system message header shows the current phase. The stop condition
+applies after the final phase.
 
 ## Stop Condition
 <natural language from step 2 — when this is true, output <promise>DONE</promise>>
@@ -155,29 +168,35 @@ count 0→30s, 1→30s, 2→60s, 3→60s, 4→120s, 5→240s, 6→480s, 7→960s
 
 ## Each Iteration
 
-1. RECALL — Query the notebook for prior entries in this context:
+1. RECALL — Read your current cursor position from the system message
+   header (e.g., "Cursor: phase=plan, retry=0"). This is authoritative —
+   do not try to reconstruct it from notebook entries.
+   Query the notebook for context on prior work:
    ```
    LAB_NOTEBOOK_DIR="<path>" lab-notebook search "<context>" --context <context>
    ```
-   If no entries exist, this is iteration 1 — start fresh.
-   For structured queries (counts, comparisons):
+   If no entries exist, this is the first iteration — start fresh.
+   For structured queries:
    ```
-   LAB_NOTEBOOK_DIR="<path>" lab-notebook sql "SELECT ts, type, <schema-fields>, substr(content,1,120) FROM entries WHERE context='<context>' ORDER BY ts DESC LIMIT 10"
+   LAB_NOTEBOOK_DIR="<path>" lab-notebook sql "SELECT ts, type, tags, substr(content,1,200) FROM entries WHERE context='<context>' ORDER BY ts DESC LIMIT 10"
    ```
    *(if pacing)* Count consecutive entries of the low-activity category
    from the top of the results to determine the current backoff position.
 
-2. ASSESS — Based on recalled state: what has been done, what remains,
-   what should this iteration focus on?
+2. ASSESS — Based on the cursor position and recalled notebook entries:
+   what has been done, what remains, what should this iteration focus on?
    *(if categories)* Check recent entry categories to understand loop trajectory.
-   *(if phases)* Determine which phase we're in based on logged entries.
 
 3. EXECUTE — Do the work for this iteration.
 
-4. LOG — Record what you did and learned:
+4. LOG — Record what you did and learned. The system message provides
+   an emit command template with `--tags` pre-filled from the current
+   cursor position — use it. Log whatever is useful (observations,
+   decisions, dead-ends, milestones). No required format.
    ```
    LAB_NOTEBOOK_DIR="<path>" lab-notebook emit \
      --context <context> --type <entry-type> \
+     --tags "<cursor-tags-from-system-message>" \
      [--<schema-field> value ...] [--extra key=value ...] \
      "concise summary of what happened this iteration"
    ```
@@ -189,9 +208,15 @@ count 0→30s, 1→30s, 2→60s, 3→60s, 4→120s, 5→240s, 6→480s, 7→960s
    Use the schema field if available (e.g., `--change_type heartbeat`),
    otherwise `--extra category=<chosen>`.
 
-5. CHECK — Evaluate the stop condition. If met, output <promise>DONE</promise>.
-   Otherwise, summarize remaining work (the next iteration will see this
-   in the notebook via step 1).
+5. CHECK — Signal the outcome of this iteration's work:
+   - If the work for the current cursor position succeeded:
+     include "PHASE COMPLETE" in your response. The hook advances
+     the cursor automatically.
+   - If the work failed and should be retried or skipped:
+     include "PHASE FAILED" in your response. The hook advances
+     the retry dimension (or skips on exhaust).
+   - If the overall stop condition is met (all work genuinely done):
+     output <promise>DONE</promise> to exit the loop entirely.
    *(if pacing)* Compute sleep duration: walk the backoff sequence by
    the consecutive low-activity count from RECALL. If past the end of
    the explicit sequence, double the last value (capped). Execute:
@@ -202,14 +227,15 @@ count 0→30s, 1→30s, 2→60s, 3→60s, 4→120s, 5→240s, 6→480s, 7→960s
 
 ## Stateful Mechanisms
 
-The generated prompt leverages all available cross-iteration state. The last four are provided by ralph-loop; lisa-loop adds the first.
+The generated prompt leverages all available cross-iteration state. The first three are provided by lisa-wiggum; lisa-loop adds notebook entries.
 
 | Mechanism | How | Role |
 |-----------|-----|------|
 | **Notebook/logbook entries** | `lab-notebook search/sql` | Primary — structured, queryable, persists beyond the loop |
+| **Cursor position** | System message header from lisa-wiggum | Primary — mechanical, no reconstruction needed |
+| **Traversal history** | System message from lisa-wiggum | Secondary — see signal outcomes of prior iterations |
 | **Files on disk** | Read modified files | Secondary — see your own prior work |
 | **Git history** | `git log`, `git diff` | Secondary — what changed between iterations |
-| **Iteration counter** | Shown in ralph-loop system message | Secondary — know which iteration you're on |
 | **Test/build results** | Run tests, check output | Secondary — backpressure from verification |
 
 ---
@@ -221,9 +247,12 @@ To build a lisa-loop prompt manually instead of using interactive setup:
 1. Pick your state store (any lab-notebook path)
 2. Pick a context name (all entries share this key)
 3. Write a prompt following the 5-phase pattern above
-4. Invoke directly:
+4. Write the prompt to a file and invoke directly:
    ```
-   /ralph-loop:ralph-loop "<your prompt>" --max-iterations 10 --completion-promise "DONE"
+   /lisa-wiggum:lisa-loop --prompt-file <path-to-prompt.md> \
+     --store <notebook-path> --context <context-slug> \
+     --dim phase plan execute test \
+     --max-iterations 10 --completion-promise "DONE"
    ```
 
 **Key principles for hand-crafted prompts:**
@@ -231,8 +260,9 @@ To build a lisa-loop prompt manually instead of using interactive setup:
 - Always include a LOG phase — this is what feeds the next iteration's RECALL
 - Handle iteration 1 explicitly ("if no entries, start fresh")
 - Include command templates for `lab-notebook` — the agent needs the CLI syntax
+- Cursor position is provided in the system message — the prompt does not need milestone-parsing logic
+- The agent must output `PHASE COMPLETE` or `PHASE FAILED` to signal per-cell outcomes, and `<promise>DONE</promise>` only for final exit
 - Make the stop condition concrete and evaluable, not vague
 - Add `--max-iterations` as a safety cap even if you have a completion promise
-- The agent must output `<promise>DONE</promise>` (with XML tags), not bare `DONE`. The `--completion-promise "DONE"` flag tells ralph-loop what text to look for; the `<promise>` wrapper is required by ralph-loop's stop hook
 
 $ARGUMENTS

--- a/SKILL.md
+++ b/SKILL.md
@@ -211,7 +211,8 @@ count 0→30s, 1→30s, 2→60s, 3→60s, 4→120s, 5→240s, 6→480s, 7→960s
    ```
    Note: `--tags` is only valid if the schema includes a `tags` field
    (check the Step 1 schema probe). The system message emit template
-   already omits `--tags` when no cursor tags are set.
+   already omits `--tags` when no cursor tags are set (including when
+   no `--dim` flags are configured).
    Use schema-defined fields as top-level flags (e.g., `--status keep
    --change_type progress`). Use `--extra` only for undeclared fields.
    If the logging command fails, note the error and continue —
@@ -274,6 +275,7 @@ To build a lisa-loop prompt manually instead of using interactive setup:
    /lisa-wiggum:lisa-loop --prompt-file <path-to-prompt.md> \
      --store <notebook-path> --context <context-slug> \
      --dim phase plan execute test \
+     --dim retry 0 1 2 --on-exhaust skip \
      --max-iterations 10 --completion-promise "DONE"
    ```
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -70,7 +70,7 @@ Then ask:
 
 > How many retries per phase if it fails? (0 = no retries; default 2)
 
-If retries > 0 (e.g., 2): add `--dim retry 0 1 2 --on-exhaust skip` to the Step 6 invocation (values are `0 1 ... N` for N retries). If retries = 0: omit the retry dimension; in this case PHASE FAILED advances the phase (same effect as PHASE COMPLETE — e.g., with only `--dim phase plan review execute`, both signals advance to the next phase).
+If retries > 0 (e.g., 2): add `--dim retry 0 1 2 --on-exhaust skip` as the final (innermost) `--dim` flag in the Step 6 invocation — after `--dim phase` (values are `0 1 ... N` for N retries). If retries = 0: omit the retry dimension; in this case PHASE FAILED advances the phase (same effect as PHASE COMPLETE — e.g., with only `--dim phase plan review execute`, both signals advance to the next phase).
 
 ### Step 3b — Categories
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -70,7 +70,7 @@ Then ask:
 
 > How many retries per phase if it fails? (0 = no retries; default 2)
 
-If retries > 0 (e.g., 2): add `--dim retry 0 1 2 --on-exhaust skip` to the Step 6 invocation (values are `0 1 ... N` for N retries). If retries = 0: omit the retry dimension; in this case PHASE FAILED advances the phase (same effect as PHASE COMPLETE).
+If retries > 0 (e.g., 2): add `--dim retry 0 1 2 --on-exhaust skip` to the Step 6 invocation (values are `0 1 ... N` for N retries). If retries = 0: omit the retry dimension; in this case PHASE FAILED advances the phase (same effect as PHASE COMPLETE — e.g., with only `--dim phase plan review execute`, both signals advance to the next phase).
 
 ### Step 3b — Categories
 

--- a/references/flattening-nested-loops.md
+++ b/references/flattening-nested-loops.md
@@ -48,10 +48,10 @@ This creates a 3D cursor: `(item, phase, retry)`.
 
 | Signal | Effect |
 |--------|--------|
-| `PHASE COMPLETE` | Advances outer dimension (e.g., next phase), resets inner dimensions |
+| `PHASE COMPLETE` | Advances second-to-innermost dimension (e.g., `phase` when `retry` is innermost), resets all inner dimensions |
 | `PHASE FAILED` | Advances innermost dimension (retry) |
 | Neither | Cursor unchanged, iteration advances |
-| Retry exhausted | `--on-exhaust skip` skips to next outer value |
+| Retry exhausted | Advances second-to-innermost (skip is the hardcoded behavior; `--on-exhaust skip` is stored in the state file but currently not read by the hook — reserved for future extension) |
 | All dimensions exhausted | Loop ends (cursor complete) |
 | `<promise>DONE</promise>` | Loop ends immediately |
 
@@ -268,7 +268,6 @@ Lisa iteration 7 | Cursor: item=102, phase=review, retry=0
 4: item=101,phase=test,retry=0 -> success
 5: item=102,phase=plan,retry=0 -> success
 6: item=102,phase=review,retry=0 -> none
-...
 ```
 
 The agent reads this, sees it needs to do adversarial review for issue #102,
@@ -286,4 +285,7 @@ Add more `--dim` flags. For example, a 4-level cursor:
 ```
 
 Each additional dimension is just another `--dim` flag. The stop hook
-handles all the transition logic mechanically.
+handles all the transition logic mechanically. `PHASE COMPLETE` always
+advances the second-to-innermost dimension — here `phase`, not `dataset`
+or `model`. `PHASE FAILED` advances `retry` (innermost). When `retry` is
+exhausted, the hook overflows to `phase` (second-to-innermost).

--- a/references/flattening-nested-loops.md
+++ b/references/flattening-nested-loops.md
@@ -1,30 +1,73 @@
-# Flattening Nested Loops in Lisa-Loop
+# Multi-Dimensional Cursors in Lisa-Loop
 
 ## When to Use
 
 You have multiple items (issues, experiments, datasets, etc.) and each item
 requires a multi-phase workflow. Your instinct is nested loops — an outer
-loop over items and an inner loop over phases. Ralph-loop only supports one
-active loop (single state file), so you flatten the nesting into one loop
-with a multi-dimensional cursor tracked in lab-notebook.
+loop over items and an inner loop over phases. Lisa-wiggum supports this
+natively with `--dim` flags that define the cursor dimensions. The hook
+flattens the nesting into one loop with mechanical cursor advancement.
 
 ## Pattern
 
 ```
-nested (impossible):              flattened (works):
+nested (conceptual):              lisa-wiggum (actual):
 
-for item in 1..N:                 single lisa-loop:
-  for phase in A..D:                read (item, phase) from notebook
-    do work                         do work for (item, phase)
-    if phase fails: retry           advance cursor:
-                                      phase failed       → same item, same phase
-                                      phase succeeded     → same item, next phase
-                                      last phase passed   → next item, first phase
-                                      last item completed → LOOP_COMPLETE
+for item in 1..N:                 single loop with --dim flags:
+  for phase in A..D:                cursor position in system message
+    do work                         do work for current position
+    if phase fails: retry           PHASE COMPLETE → advance outer dim
+                                    PHASE FAILED   → advance retry dim
+                                    cursor exhausted → loop ends
 ```
 
-Lab-notebook replaces both loop variables. Each iteration is stateless —
-it reconstructs its position entirely from notebook queries.
+The cursor position is injected into the system message by the stop hook.
+Each iteration reads its position from the header (e.g.,
+`Cursor: item=3, phase=execute, retry=0`), does one unit of work, and
+signals the outcome. The hook advances the cursor mechanically.
+
+## How `--dim` Flags Work
+
+Each `--dim` flag defines one dimension of the cursor. Order matters —
+dimensions are listed outer-to-inner. The innermost dimension is the
+retry/failure axis.
+
+```bash
+/lisa-wiggum:lisa-loop --prompt-file task.md \
+  --store /path/to/notebook --context my-repo/fix-issues \
+  --dim item 101 102 103 \
+  --dim phase plan review execute test \
+  --dim retry 0 1 2 \
+  --on-exhaust skip \
+  --max-iterations 50 --completion-promise "DONE"
+```
+
+This creates a 3D cursor: `(item, phase, retry)`.
+
+### Signal-driven advancement
+
+| Signal | Effect |
+|--------|--------|
+| `PHASE COMPLETE` | Advances outer dimension (e.g., next phase), resets inner dimensions |
+| `PHASE FAILED` | Advances innermost dimension (retry) |
+| Neither | Cursor unchanged, iteration advances |
+| Retry exhausted | `--on-exhaust skip` skips to next outer value |
+| All dimensions exhausted | Loop ends (cursor complete) |
+| `<promise>DONE</promise>` | Loop ends immediately |
+
+### Examples
+
+Success at `(item=101, phase=plan, retry=0)`:
+  -> advances to `(item=101, phase=review, retry=0)`
+
+Failure at `(item=101, phase=execute, retry=0)`:
+  -> advances to `(item=101, phase=execute, retry=1)`
+
+Failure at `(item=101, phase=execute, retry=2)` (retry exhausted, on_exhaust=skip):
+  -> advances to `(item=101, phase=test, retry=0)`
+
+Success at `(item=101, phase=test, retry=0)` (last phase):
+  -> advances to `(item=102, phase=plan, retry=0)`
 
 ## Notebook Conventions
 
@@ -38,144 +81,92 @@ training/sweep-architectures
 
 All entries from the loop share this context.
 
-### Entry types for cursor tracking
+### Entry types
 
-Use these entry types to track progress:
+These entry types are useful for tracking work, but they are not required
+for cursor advancement (the cursor is mechanical):
 
 | Entry type   | When to emit | Purpose |
 |-------------|--------------|---------|
-| `milestone` | A phase completes successfully for an item | Marks phase completion — this is what the cursor reads |
-| `decision`  | A plan is formed, a review is done, a choice is made | Records reasoning for the current phase |
-| `dead-end`  | A phase attempt fails | Records what went wrong, prevents repeating the same failure |
-| `observation` | Intermediate findings during a phase | Context for later phases |
+| `milestone` | A unit of work completes successfully | Records what was accomplished |
+| `decision`  | A plan is formed, a review is done, a choice is made | Records reasoning |
+| `dead-end`  | A work attempt fails | Records what went wrong |
+| `observation` | Intermediate findings | Context for later iterations |
 
-### Content format for milestones (critical)
+### Tagging entries with cursor position
 
-Milestone entries MUST follow this exact format so queries can parse them:
-
-```
-Item #<N>: <PHASE_NAME> COMPLETE — <one-line summary>
-```
-
-Examples:
-```
-Item #3: PLAN COMPLETE — will refactor DataLoader to support streaming
-Item #3: REVIEW COMPLETE — revised plan to handle edge case in batch collation
-Item #3: EXECUTE COMPLETE — committed refactor in 2 files, 47 lines changed
-Item #3: TEST COMPLETE — single-gpu, ddp, fsdp all pass
-```
-
-When all phases for an item pass, emit one final milestone:
-```
-Item #3: ALL PHASES COMPLETE
-```
-
-## Query Recipes
-
-Replace `<STORE>` with the absolute notebook path and `<CTX>` with the context.
-
-### Count completed items
+The system message provides an `emit` command template with `--tags`
+pre-filled from the current cursor position. Use it so entries are
+queryable by position:
 
 ```bash
-LAB_NOTEBOOK_DIR="<STORE>" lab-notebook sql \
-  "SELECT COUNT(DISTINCT substr(content, 7, instr(substr(content,7),':')-1))
-   FROM entries
-   WHERE context='<CTX>' AND type='milestone'
-     AND content LIKE '%ALL PHASES COMPLETE%'"
+LAB_NOTEBOOK_DIR="/path/to/notebook" lab-notebook emit \
+  --context my-repo/fix-issues --type milestone \
+  --tags "item=101,phase=plan" \
+  "Planned approach: refactor DataLoader for streaming"
 ```
 
-### Find current item and last completed phase
-
+Query entries for a specific position:
 ```bash
-LAB_NOTEBOOK_DIR="<STORE>" lab-notebook sql \
-  "SELECT ts, substr(content,1,120) FROM entries
-   WHERE context='<CTX>' AND type='milestone'
-   ORDER BY ts DESC LIMIT 5"
+LAB_NOTEBOOK_DIR="/path/to/notebook" lab-notebook sql \
+  "SELECT ts, type, tags, substr(content,1,200) FROM entries
+   WHERE context='my-repo/fix-issues' AND tags LIKE '%item=101%'
+   ORDER BY ts DESC LIMIT 10"
 ```
 
-Read the results top-down:
-- If the most recent milestone is `Item #N: ALL PHASES COMPLETE` and N is the last item, all work is done — skip to CHECK and emit DONE.
-- If the most recent milestone is `Item #N: ALL PHASES COMPLETE` and N is not the last item, the current item is N+1, starting at the first phase.
-- If the most recent milestone is `Item #N: <PHASE> COMPLETE`, the current item is N, and the next phase follows `<PHASE>`.
-- If there are no milestones, this is iteration 1 — start at item 1, phase 1.
+## Prompt Template for Multi-Dimensional Work
 
-### Check for dead-ends on current item and phase
-
-```bash
-LAB_NOTEBOOK_DIR="<STORE>" lab-notebook search "Item #<N>: <PHASE> FAILED" --context <CTX> --type dead-end
-```
-
-## Transition Logic Template
-
-Drop this into the `## Each Iteration` section of a lisa-loop prompt.
-Replace placeholders with your specific items and phases.
+The prompt for a multi-dimensional loop is simpler than the old
+flattening approach because the cursor handles all transition logic.
 
 ```
-## Items
-<ITEMS — numbered list, e.g.:>
-1. GitHub issue #101 — fix data loader race condition
-2. GitHub issue #102 — add retry logic to API client
-3. GitHub issue #103 — update schema migration
+## State Store
+Notebook: <absolute-path>
+Context: <context-slug>
+Available entry types: <from lab-notebook schema>
+
+## Goal
+<task description — what items, what phases, what success looks like>
 
 ## Phases (per item)
-<PHASES — ordered list, e.g.:>
-A. PLAN — read the issue, understand the code, write an implementation plan
-B. REVIEW — adversarially critique the plan, revise if needed
-C. EXECUTE — implement the revised plan, commit
-D. TEST — run smoke tests, fix failures until all pass
+A. PLAN — <description>
+B. REVIEW — <description>
+C. EXECUTE — <description>
+D. TEST — <description>
+
+## Stop Condition
+<natural language — when this is true, output <promise>DONE</promise>>
 
 ## Each Iteration
 
-1. RECALL — Query the notebook to find where you are:
+1. RECALL — Read your current cursor position from the system message
+   header (e.g., "Cursor: item=101, phase=plan, retry=0").
+   Query the notebook for context on the current item and phase:
    ```
-   LAB_NOTEBOOK_DIR="<STORE>" lab-notebook sql \
-     "SELECT ts, substr(content,1,120) FROM entries
-      WHERE context='<CTX>' AND type='milestone'
+   LAB_NOTEBOOK_DIR="<path>" lab-notebook sql \
+     "SELECT ts, type, tags, substr(content,1,200) FROM entries
+      WHERE context='<ctx>' AND tags LIKE '%item=<current>%'
       ORDER BY ts DESC LIMIT 10"
    ```
-   Parse the most recent milestones to determine:
-   - current_item: which item number you are working on
-   - current_phase: which phase to execute next
-   - If no milestones exist → current_item=1, current_phase=A
-   - If the most recent milestone is "Item #N: ALL PHASES COMPLETE" and N
-     is the last item → all work is done, skip to CHECK and emit DONE
 
-   Also check for dead-ends on the current item and phase:
+2. ASSESS — Based on cursor position and notebook entries:
+   what does this phase require? Any prior dead-ends to learn from?
+
+3. EXECUTE — Do the work for the current (item, phase).
+
+4. LOG — Record the outcome using the emit template from the system
+   message (it has --tags pre-filled):
    ```
-   LAB_NOTEBOOK_DIR="<STORE>" lab-notebook search "Item #<current_item>: <current_phase> FAILED" \
-     --context <CTX> --type dead-end
+   LAB_NOTEBOOK_DIR="<path>" lab-notebook emit \
+     --context <ctx> --type <milestone|decision|dead-end> \
+     --tags "<cursor-tags>" \
+     "<summary of what happened>"
    ```
 
-2. ASSESS — Decide what to do this iteration:
-   - If the dead-end search returned results for the current phase: adjust approach based on what failed
-   - Otherwise: proceed with the phase's defined work
-
-3. EXECUTE — Do the work for (current_item, current_phase).
-
-4. LOG — Record the outcome:
-   - On success:
-     ```
-     LAB_NOTEBOOK_DIR="<STORE>" lab-notebook emit \
-       --context <CTX> --type milestone \
-       "Item #<N>: <PHASE> COMPLETE — <summary>"
-     ```
-   - If this was the last phase for this item, also emit:
-     ```
-     LAB_NOTEBOOK_DIR="<STORE>" lab-notebook emit \
-       --context <CTX> --type milestone \
-       "Item #<N>: ALL PHASES COMPLETE"
-     ```
-   - On failure:
-     ```
-     LAB_NOTEBOOK_DIR="<STORE>" lab-notebook emit \
-       --context <CTX> --type dead-end \
-       "Item #<N>: <PHASE> FAILED — <what went wrong>"
-     ```
-
-5. CHECK — Evaluate stop condition:
-   - Count items with "ALL PHASES COMPLETE" milestones
-   - If count == total items → output <promise>DONE</promise>
-   - Otherwise → summarize: "Completed <X>/<TOTAL>. Next: Item #<N>, phase <P>."
+5. CHECK — Signal the outcome:
+   - Work succeeded → include "PHASE COMPLETE"
+   - Work failed → include "PHASE FAILED"
+   - All items complete → output <promise>DONE</promise>
 ```
 
 ## Worked Example: 9 GitHub Issues
@@ -183,9 +174,22 @@ D. TEST — run smoke tests, fix failures until all pass
 ### Scenario
 
 Solve GitHub issues #101 through #109. Each issue goes through:
-plan → adversarial review → execute → smoke test (single GPU, DDP, FSDP).
+plan -> adversarial review -> execute -> smoke test.
 
-### Complete prompt (ready for ralph-loop)
+### Invocation
+
+```bash
+/lisa-wiggum:lisa-loop --prompt-file /tmp/lisa-loop-fix-9-issues.md \
+  --store /lustre/orion/lrn091/proj-shared/cwang31/lab-notebook \
+  --context my-repo/fix-9-issues \
+  --dim item 101 102 103 104 105 106 107 108 109 \
+  --dim phase plan review execute test \
+  --dim retry 0 1 2 \
+  --on-exhaust skip \
+  --max-iterations 50 --completion-promise "DONE"
+```
+
+### Prompt (written to `/tmp/lisa-loop-fix-9-issues.md`)
 
 ```
 ## State Store
@@ -197,24 +201,9 @@ Available entry types: observation, decision, dead-end, question, milestone
 Solve GitHub issues #101 through #109 sequentially, each through a full
 plan-review-execute-test workflow.
 
-## Items
-1. Item #101 (GitHub issue)
-2. Item #102 (GitHub issue)
-3. Item #103 (GitHub issue)
-4. Item #104 (GitHub issue)
-5. Item #105 (GitHub issue)
-6. Item #106 (GitHub issue)
-7. Item #107 (GitHub issue)
-8. Item #108 (GitHub issue)
-9. Item #109 (GitHub issue)
-
-Each item is a GitHub issue in this repository. Use /gh-skills to fetch
-details during the PLAN phase.
-
 ## Phases (per item)
 A. PLAN — Fetch the issue with /gh-skills. Read all relevant code. Write a
-   complete, self-contained implementation plan. Do NOT enter plan mode
-   (operator is hands-off). Log plan as a decision entry.
+   complete, self-contained implementation plan. Log plan as a decision entry.
 B. REVIEW — Adopt an adversarial reviewer mindset. Critique the plan for:
    weaknesses, missed edge cases, interactions with other code, test gaps.
    For each critique, either defend with evidence or acknowledge and revise.
@@ -225,115 +214,76 @@ D. TEST — Run smoke tests: single GPU, DDP, FSDP. If any fail, diagnose
    and fix. Repeat until all three pass.
 
 ## Stop Condition
-All 9 issues have "ALL PHASES COMPLETE" milestone entries → <promise>DONE</promise>
+All 9 issues solved — the cursor will exhaust naturally when the last item's
+last phase succeeds. Output <promise>DONE</promise> when complete.
 
 ## Each Iteration
 
-1. RECALL — Query the notebook:
+1. RECALL — Read cursor position from the system message header
+   (e.g., "Cursor: item=103, phase=review, retry=0").
+   Query the notebook for context on the current item:
    ```
    LAB_NOTEBOOK_DIR="/lustre/orion/lrn091/proj-shared/cwang31/lab-notebook" \
      lab-notebook sql \
-     "SELECT ts, substr(content,1,120) FROM entries
-      WHERE context='my-repo/fix-9-issues' AND type='milestone'
-      ORDER BY ts DESC LIMIT 15"
-   ```
-   Determine current_item and current_phase from the most recent milestones.
-   If no milestones → start at Item #101, phase PLAN.
-   If the most recent milestone is "Item #109: ALL PHASES COMPLETE",
-   all work is done — skip to CHECK and emit DONE.
-
-   Check for dead-ends on current item and phase:
-   ```
-   LAB_NOTEBOOK_DIR="/lustre/orion/lrn091/proj-shared/cwang31/lab-notebook" \
-     lab-notebook search "Item #<current>: <current_phase> FAILED" \
-     --context my-repo/fix-9-issues --type dead-end
+     "SELECT ts, type, tags, substr(content,1,200) FROM entries
+      WHERE context='my-repo/fix-9-issues'
+        AND tags LIKE '%item=<current_item>%'
+      ORDER BY ts DESC LIMIT 10"
    ```
 
-2. ASSESS — Based on recalled state:
+2. ASSESS — Based on cursor position and recalled entries:
    - Which issue am I on? Which phase?
    - Any prior dead-ends to learn from?
    - What does this phase require?
 
 3. EXECUTE — Do the work for the current phase of the current issue.
 
-4. LOG — Record the outcome:
-   On phase success:
+4. LOG — Record the outcome using the emit template from the system message:
    ```
    LAB_NOTEBOOK_DIR="/lustre/orion/lrn091/proj-shared/cwang31/lab-notebook" \
      lab-notebook emit --context my-repo/fix-9-issues --type milestone \
-     "Item #<N>: <PHASE> COMPLETE — <summary>"
+     --tags "<cursor-tags-from-system-message>" \
+     "<summary of what happened>"
    ```
-   When all 4 phases pass for an issue:
-   ```
-   LAB_NOTEBOOK_DIR="/lustre/orion/lrn091/proj-shared/cwang31/lab-notebook" \
-     lab-notebook emit --context my-repo/fix-9-issues --type milestone \
-     "Item #<N>: ALL PHASES COMPLETE"
-   ```
-   On failure:
-   ```
-   LAB_NOTEBOOK_DIR="/lustre/orion/lrn091/proj-shared/cwang31/lab-notebook" \
-     lab-notebook emit --context my-repo/fix-9-issues --type dead-end \
-     "Item #<N>: <PHASE> FAILED — <what went wrong>"
-   ```
+   On failure, use `--type dead-end` instead.
 
-5. CHECK — Count completed issues:
-   ```
-   LAB_NOTEBOOK_DIR="/lustre/orion/lrn091/proj-shared/cwang31/lab-notebook" \
-     lab-notebook sql \
-     "SELECT COUNT(DISTINCT substr(content, 7, instr(substr(content,7),':')-1))
-      FROM entries
-      WHERE context='my-repo/fix-9-issues' AND type='milestone'
-        AND content LIKE '%ALL PHASES COMPLETE%'"
-   ```
-   If count == 9 → <promise>DONE</promise>
-   Otherwise → "Completed <X>/9. Next: Issue #<N>, phase <P>."
+5. CHECK — Signal the outcome:
+   - Phase work succeeded → include "PHASE COMPLETE"
+   - Phase work failed → include "PHASE FAILED"
+   - All 9 issues complete → output <promise>DONE</promise>
 ```
 
-### Example notebook state mid-run (after completing 2 issues, mid-way through 3rd)
+### Example system message mid-run
+
+After completing issue #101 and starting #102's review phase, the system
+message header would show:
 
 ```
-ts                    type        content
-2026-03-28T21:20:00   decision    Item #101: plan is to refactor the DataLoader...
-2026-03-28T21:20:30   milestone   Item #101: PLAN COMPLETE — refactor DataLoader for streaming
-2026-03-28T21:21:00   decision    Item #101: review found edge case in batch collation, revised
-2026-03-28T21:21:30   milestone   Item #101: REVIEW COMPLETE — added batch boundary handling
-2026-03-28T21:23:00   milestone   Item #101: EXECUTE COMPLETE — committed in abc1234
-2026-03-28T21:25:00   milestone   Item #101: TEST COMPLETE — single-gpu, ddp, fsdp pass
-2026-03-28T21:25:01   milestone   Item #101: ALL PHASES COMPLETE
-2026-03-28T21:26:00   decision    Item #102: plan is to add retry logic to API client...
-2026-03-28T21:26:30   milestone   Item #102: PLAN COMPLETE — exponential backoff in api_client.py
-2026-03-28T21:27:00   milestone   Item #102: REVIEW COMPLETE — no revisions needed
-2026-03-28T21:28:00   milestone   Item #102: EXECUTE COMPLETE — committed in def5678
-2026-03-28T21:29:00   dead-end    Item #102: TEST FAILED — DDP test hangs on barrier sync
-2026-03-28T21:30:00   milestone   Item #102: TEST COMPLETE — fixed barrier, all pass
-2026-03-28T21:30:01   milestone   Item #102: ALL PHASES COMPLETE
-2026-03-28T21:31:00   decision    Item #103: plan is to update schema migration...
-2026-03-28T21:31:30   milestone   Item #103: PLAN COMPLETE — add nullable column, backfill
+Lisa iteration 7 | Cursor: item=102, phase=review, retry=0
+
+## Traversal
+1: item=101,phase=plan,retry=0 -> success
+2: item=101,phase=review,retry=0 -> success
+3: item=101,phase=execute,retry=0 -> success
+4: item=101,phase=test,retry=0 -> success
+5: item=102,phase=plan,retry=0 -> success
+6: item=102,phase=review,retry=0 -> none
+...
 ```
 
-An agent reading this state at the next iteration would:
-1. See 2 "ALL PHASES COMPLETE" entries → 2 items done
-2. See `Item #103: PLAN COMPLETE` as the most recent milestone → current item is #103, next phase is REVIEW
-3. Proceed with adversarial review of item #103's plan
+The agent reads this, sees it needs to do adversarial review for issue #102,
+queries the notebook for #102's plan entries, and proceeds.
 
 ## Generalizing to Deeper Nesting
 
-The same pattern extends to any depth. For 3 levels (item, phase, attempt):
+Add more `--dim` flags. For example, a 4-level cursor:
 
-```
-Cursor: (item=N, phase=P, attempt=A)
-
-Transitions:
-  attempt failed, retries left     → (N, P, A+1)
-  attempt succeeded                → (N, next_phase, 1)
-  last phase succeeded             → (N+1, first_phase, 1)
-  last item, last phase succeeded  → LOOP_COMPLETE
+```bash
+--dim dataset mnist cifar imagenet \
+--dim model resnet vgg transformer \
+--dim phase train eval \
+--dim retry 0 1
 ```
 
-Each level needs its own **completion signal** in the notebook. The query
-reconstructs all dimensions of the cursor from the most recent entries.
-The prompt's transition logic is the only thing that changes — the
-notebook conventions and query patterns stay the same.
-
-Define a maximum attempt count in the prompt. When retries are exhausted,
-emit a dead-end for the item and advance to the next item.
+Each additional dimension is just another `--dim` flag. The stop hook
+handles all the transition logic mechanically.

--- a/references/flattening-nested-loops.md
+++ b/references/flattening-nested-loops.md
@@ -55,7 +55,7 @@ This creates a 3D cursor: `(item, phase, retry)`.
 | All dimensions exhausted | Loop ends (cursor complete) |
 | `<promise>DONE</promise>` | Loop ends immediately |
 
-*Note: `--on-exhaust skip` is stored in the state file but currently not read by the hook — the skip behavior is hardcoded. The flag is reserved for future extension.*
+*Note: `--on-exhaust skip` is stored in the state file but the hook does not read it — skip (reset innermost, advance second-to-innermost) is the only implemented on-exhaust behavior. The flag is reserved for future alternatives.*
 
 ### Examples
 

--- a/references/flattening-nested-loops.md
+++ b/references/flattening-nested-loops.md
@@ -50,10 +50,12 @@ This creates a 3D cursor: `(item, phase, retry)`.
 |--------|--------|
 | `PHASE COMPLETE` | Advances second-to-innermost dimension (e.g., `phase` when `retry` is innermost), resets all inner dimensions |
 | `PHASE FAILED` | Advances innermost dimension (retry) |
-| Neither | Cursor unchanged, iteration advances |
-| Retry exhausted | Advances second-to-innermost (skip is the hardcoded behavior; `--on-exhaust skip` is stored in the state file but currently not read by the hook — reserved for future extension) |
+| Neither | Cursor unchanged; same position reruns next iteration |
+| Retry exhausted | Resets innermost, advances second-to-innermost (hardcoded skip behavior) |
 | All dimensions exhausted | Loop ends (cursor complete) |
 | `<promise>DONE</promise>` | Loop ends immediately |
+
+*Note: `--on-exhaust skip` is stored in the state file but currently not read by the hook — the skip behavior is hardcoded. The flag is reserved for future extension.*
 
 ### Examples
 

--- a/references/flattening-nested-loops.md
+++ b/references/flattening-nested-loops.md
@@ -164,11 +164,13 @@ D. TEST — <description>
      --tags "<cursor-tags>" \
      "<summary of what happened>"
    ```
+   (`--tags` requires a `tags` field in the store schema — check `lab-notebook schema`.)
 
 5. CHECK — Signal the outcome:
    - Work succeeded → include "PHASE COMPLETE"
    - Work failed → include "PHASE FAILED"
    - All items complete → output <promise>DONE</promise>
+   - Work still in progress → include neither signal; same position reruns
 ```
 
 ## Worked Example: 9 GitHub Issues
@@ -182,7 +184,7 @@ plan -> adversarial review -> execute -> smoke test.
 
 ```bash
 /lisa-wiggum:lisa-loop --prompt-file /tmp/lisa-loop-fix-9-issues.md \
-  --store /lustre/orion/lrn091/proj-shared/cwang31/lab-notebook \
+  --store /data/lab-notebook \
   --context my-repo/fix-9-issues \
   --dim item 101 102 103 104 105 106 107 108 109 \
   --dim phase plan review execute test \
@@ -195,7 +197,7 @@ plan -> adversarial review -> execute -> smoke test.
 
 ```
 ## State Store
-Notebook: /lustre/orion/lrn091/proj-shared/cwang31/lab-notebook
+Notebook: /data/lab-notebook
 Context: my-repo/fix-9-issues
 Available entry types: observation, decision, dead-end, question, milestone
 
@@ -225,7 +227,7 @@ last phase succeeds. Output <promise>DONE</promise> when complete.
    (e.g., "Cursor: item=103, phase=review, retry=0").
    Query the notebook for context on the current item:
    ```
-   LAB_NOTEBOOK_DIR="/lustre/orion/lrn091/proj-shared/cwang31/lab-notebook" \
+   LAB_NOTEBOOK_DIR="/data/lab-notebook" \
      lab-notebook sql \
      "SELECT ts, type, tags, substr(content,1,200) FROM entries
       WHERE context='my-repo/fix-9-issues'
@@ -242,7 +244,7 @@ last phase succeeds. Output <promise>DONE</promise> when complete.
 
 4. LOG — Record the outcome using the emit template from the system message:
    ```
-   LAB_NOTEBOOK_DIR="/lustre/orion/lrn091/proj-shared/cwang31/lab-notebook" \
+   LAB_NOTEBOOK_DIR="/data/lab-notebook" \
      lab-notebook emit --context my-repo/fix-9-issues --type milestone \
      --tags "<cursor-tags-from-system-message>" \
      "<summary of what happened>"

--- a/references/flattening-nested-loops.md
+++ b/references/flattening-nested-loops.md
@@ -50,7 +50,7 @@ This creates a 3D cursor: `(item, phase, retry)`.
 |--------|--------|
 | `PHASE COMPLETE` | Advances second-to-innermost dimension (e.g., `phase` when `retry` is innermost), resets all inner dimensions |
 | `PHASE FAILED` | Advances innermost dimension (retry) |
-| Neither | Cursor unchanged; same position reruns next iteration |
+| Neither | Cursor unchanged; same position reruns next iteration (`none` in traversal history) |
 | Retry exhausted | Resets innermost, advances second-to-innermost (hardcoded skip behavior) |
 | All dimensions exhausted | Loop ends (cursor complete) |
 | `<promise>DONE</promise>` | Loop ends immediately |


### PR DESCRIPTION
## Summary
- Replaces ralph-loop backend with lisa-wiggum's `/lisa-wiggum:lisa-loop` command
- RECALL reads cursor position from system message header instead of parsing notebook milestones
- CHECK uses `PHASE COMPLETE`/`PHASE FAILED` signals for mechanical cursor advancement; `<promise>DONE</promise>` only for final exit
- LOG drops the strict `Item #N: PHASE COMPLETE — summary` format constraint
- Phases from step 3a become `--dim phase` flags on invocation
- Rewrites the flattening-nested-loops reference for `--dim`-based mechanical cursors

Closes #4

## Test plan
- [ ] Run `/lisa-loop --store <test-store> test task` and walk through interactive setup
- [ ] Verify generated prompt references system message cursor (not milestone parsing)
- [ ] Verify `PHASE COMPLETE`/`PHASE FAILED` signals are in the template
- [ ] Verify invocation uses `/lisa-wiggum:lisa-loop` with correct flags
- [ ] Verify LOG phase has no format constraints
- [ ] Verify flattening reference documents `--dim` pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)